### PR TITLE
Allow CORS from all origins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django==3.0.4
+django-cors-headers==3.2.1
 django-filter==2.2.0
 djangorestframework==3.11.0
 djangorestframework-csv==2.1.0

--- a/resources_guide/settings/base.py
+++ b/resources_guide/settings/base.py
@@ -50,9 +50,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/resources_guide/settings/base.py
+++ b/resources_guide/settings/base.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     'restaurants',
 
     # third-party apps
+    'corsheaders',
     'rest_framework',
     'rest_framework.authtoken',
 
@@ -51,6 +52,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/resources_guide/settings/production.py
+++ b/resources_guide/settings/production.py
@@ -26,9 +26,7 @@ DATABASES = {
 }
 
 CORS_ORIGIN_ALLOW_ALL = True
-#CORS_ORIGIN_WHITELIST = [
-#    'https://daytoneats.com/'
-#]
+CORS_ALLOW_CREDENTIALS = True
 
 on_heroku = 'DYNO' in os.environ
 if on_heroku:

--- a/resources_guide/settings/production.py
+++ b/resources_guide/settings/production.py
@@ -25,9 +25,10 @@ DATABASES = {
     }
 }
 
-CORS_ORIGIN_WHITELIST = [
-    'https://daytoneats.com/'
-]
+CORS_ORIGIN_ALLOW_ALL = True
+#CORS_ORIGIN_WHITELIST = [
+#    'https://daytoneats.com/'
+#]
 
 on_heroku = 'DYNO' in os.environ
 if on_heroku:

--- a/resources_guide/settings/production.py
+++ b/resources_guide/settings/production.py
@@ -25,6 +25,10 @@ DATABASES = {
     }
 }
 
+CORS_ORIGIN_WHITELIST = [
+    'https://daytoneats.com/'
+]
+
 on_heroku = 'DYNO' in os.environ
 if on_heroku:
     import django_heroku


### PR DESCRIPTION
- Production setup defines for allow CORS from all origins with the `django-cors-headers` package.

It may be worth investigating the Whitelist option at some point later.